### PR TITLE
feat: revert testing per asset release branches

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -2,7 +2,7 @@
 
 release:
 - base-branch:
-  - 'release/.+'
+  - 'main'
   - 'maintenance/.+/release/[0-9]+\.([0-9]+|x)\.x'
 
 # Trunk branches where changes are collected before assets are released

--- a/.github/workflows/controller-container.yaml
+++ b/.github/workflows/controller-container.yaml
@@ -20,7 +20,7 @@ on:
     branches:
       - 'maintenance/controller-container/release/[0-9]+.x.x'
       - 'maintenance/controller-container/release/[0-9]+.[0-9]+.x'
-      - 'release/controller-container'
+      - 'main'
     # Only consider pushes that change files for this asset, including ci scripts
     paths:
       - '.github/workflows/controller-container.yaml'
@@ -50,7 +50,7 @@ jobs:
       release-branches: |
         [
           'maintenance/controller-container/release/[0-9]+\.([0-9]+|x)\.x',
-          'release/controller-container'
+          'main'
         ]
       cosign-public-key: ${{ vars.COSIGN_PUBLIC_KEY }}
       slack-channel: ${{ vars.SLACK_CHANNEL }}

--- a/.github/workflows/fizzbuzz-chart.yaml
+++ b/.github/workflows/fizzbuzz-chart.yaml
@@ -19,7 +19,7 @@ on:
     branches:
       - 'maintenance/fizzbuzz-chart/release/[0-9]+.x.x'
       - 'maintenance/fizzbuzz-chart/release/[0-9]+.[0-9]+.x'
-      - 'release/fizzbuzz-chart'
+      - 'main'
     # Only consider pushes that change files for this asset, including ci scripts
     paths:
       - '.github/workflows/fizzbuzz-chart.yaml'
@@ -50,7 +50,7 @@ jobs:
       release-branches: |
         [
           'maintenance/fizzbuzz-chart/release/[0-9]+\.([0-9]+|x)\.x',
-          'release/fizzbuzz-chart'
+          'main'
         ]
       cosign-public-key: ${{ vars.COSIGN_PUBLIC_KEY }}
       slack-channel: ${{ vars.SLACK_CHANNEL }}

--- a/.github/workflows/fizzbuzz-crds-chart.yaml
+++ b/.github/workflows/fizzbuzz-crds-chart.yaml
@@ -19,7 +19,7 @@ on:
     branches:
       - 'maintenance/fizzbuzz-crds-chart/release/[0-9]+.x.x'
       - 'maintenance/fizzbuzz-crds-chart/release/[0-9]+.[0-9]+.x'
-      - 'release/fizzbuzz-crds-chart'
+      - 'main'
     # Only consider pushes that change files for this asset, including ci scripts
     paths:
       - '.github/workflows/fizzbuzz-crds-chart.yaml'
@@ -50,7 +50,7 @@ jobs:
       release-branches: |
         [
           'maintenance/fizzbuzz-crds-chart/release/[0-9]+\.([0-9]+|x)\.x',
-          'release/fizzbuzz-crds-chart'
+          'main'
         ]
       cosign-public-key: ${{ vars.COSIGN_PUBLIC_KEY }}
       slack-channel: ${{ vars.SLACK_CHANNEL }}


### PR DESCRIPTION
## :construction: Suggest a change

Revert testing releasing each asset off it's own branch since github branch protection rules aren't granular enough.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
