### PR TITLE
fix: renovate needs permission to spawn ci in prs it opens

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,6 +6,7 @@ on:
     - cron: '0 * * * *'
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write


### PR DESCRIPTION
## :construction: Suggest a change

Renovate needs extra permissions to be able to launch ci on the prs it opens.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
