### PR TITLE
refactor: update renovate schedule to not run on weekends

### DIFF
--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -25,8 +25,9 @@ module.exports = {
   // requests for dependencies unless they override the schedule.
   updateNotScheduled: false,
   timezone: "Europe/London",
+  //after 10pm and before 5am every weekday
   schedule: [
-    "at any time"
+    "* 22-23,0-4 * * 1-5"
   ],
 
   // This setting helps handle breaking changes to Renovate bot when its version changes.

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/renovate.yaml'
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 * * * 1-5'
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## :construction: Suggest a change

Update renovate schedule to only run on weekdays. External updates only between 10pm and 5am.